### PR TITLE
Open API v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Table of Contents:
   - [Errors](#errors)
   - [Gateway](#Gateway)
 - [Client](#twirp-client)
+- [Open API V3](#open-api-v3)
 - [Migrate to V2](#migrate-to-v2)
 - [How to Upgrade](#how-to-upgrade)
 
@@ -385,6 +386,21 @@ const implementation: Rpc = {
 export const jsonClient = new HaberdasherClientJSON(implementation);
 export const protobufClient = new HaberdasherClientProtobuf(implementation);
 ```
+
+## Open API V3
+
+You can now generate automatically an **OpenAPI V3** compliant spec out of your twirp protobuf definitions!
+
+We support the **Gateway** too!
+
+Add the following options to your `protoc` command:
+
+```
+--twirp_ts_opt="openapi_twirp" 
+--twirp_ts_opt="openapi_gateway"
+```
+
+Enjoy!
 
 ## Migrate to V2
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "twirp-ts",
-  "version": "2.1.1",
+  "version": "2.1.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3799,6 +3799,12 @@
         "mimic-fn": "^2.1.0"
       }
     },
+    "openapi-types": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-9.1.0.tgz",
+      "integrity": "sha512-mhXh8QN8sbErlxfxBeZ/pzgvmDn443p8CXlxwGSi2bWANZAFvjLPI0PoGjqHW+JdBbXg6uvmvM81WXaweh/SVA==",
+      "dev": true
+    },
     "optionator": {
       "version": "0.8.3",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
@@ -4639,6 +4645,11 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
+    },
+    "yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg=="
     },
     "yargs": {
       "version": "16.2.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "@protobuf-ts/plugin-framework": "^2.0.0-alpha.27",
     "dot-object": "^2.1.4",
     "path-to-regexp": "^6.2.0",
-    "ts-poet": "^4.5.0"
+    "ts-poet": "^4.5.0",
+    "yaml": "^1.10.2"
   },
   "devDependencies": {
     "@protobuf-ts/plugin": "^2.0.0-alpha.27",
@@ -34,6 +35,7 @@
     "@types/supertest": "^2.0.11",
     "http-terminator": "^3.0.0",
     "jest": "^27.0.4",
+    "openapi-types": "^9.1.0",
     "supertest": "^6.1.3",
     "ts-jest": "^27.0.3",
     "ts-proto": "^1.81.3",

--- a/src/protoc-gen-twirp-ts/gen/gateway.ts
+++ b/src/protoc-gen-twirp-ts/gen/gateway.ts
@@ -9,7 +9,7 @@ const pathToRegexpMatch = imp("match@path-to-regexp");
 
 const debug = (content: any) => writeFileSync(__dirname + "/debug.json", JSON.stringify(content, null, 2),"utf-8")
 
-enum Pattern {
+export enum Pattern {
   POST = 'post',
   GET = 'get',
   PATCH = 'patch',
@@ -33,7 +33,7 @@ export type HttpRulePattern = {
   [key in Pattern]: string
 }
 
-interface HttpOption extends HttpRulePattern {
+export interface HttpOption extends HttpRulePattern {
   body: string;
   responseBody: string
   additional_bindings: HttpOption
@@ -135,7 +135,7 @@ function matcher(url: string) {
   }).join("/");
 }
 
-function getMethod(httpSpec: HttpOption) {
+export function getMethod(httpSpec: HttpOption) {
   const possibleMethods = ["post", "get", "patch", "put", "delete"] as Pattern[];
 
   for (const method of possibleMethods) {

--- a/src/protoc-gen-twirp-ts/gen/open-api.ts
+++ b/src/protoc-gen-twirp-ts/gen/open-api.ts
@@ -1,0 +1,350 @@
+import {
+  AnyDescriptorProto,
+  DescriptorProto,
+  DescriptorRegistry, EnumDescriptorProto,
+  FieldDescriptorProto,
+  FieldDescriptorProto_Label,
+  FieldDescriptorProto_Type,
+  FileDescriptorProto,
+  MethodDescriptorProto,
+  ScalarValueType,
+  ServiceDescriptorProto,
+  SymbolTable
+} from "@protobuf-ts/plugin-framework";
+import * as yaml from 'yaml';
+import { OpenAPIV3 } from "openapi-types";
+import { createLocalTypeName } from "../local-type-name";
+import * as fs from "fs";
+
+interface OpenAPIDoc {
+  fileName: string,
+  content: string,
+}
+
+export async function genOpenAPI(ctx: any, files: readonly FileDescriptorProto[]) {
+  const documents: OpenAPIDoc[] = [];
+
+  files.forEach(file => {
+    file.service.forEach((service) => {
+      const document: OpenAPIV3.Document = {
+        openapi: "3.0.3",
+        info: {
+          title: `${service.name}`,
+          version: "" // TODO
+        },
+        paths: genPaths(ctx, file, service),
+        components: genComponents(ctx, service.method),
+      }
+
+      documents.push({
+        fileName: `${service.name?.toLowerCase()}.twirp.yaml`,
+        content: yaml.stringify(document),
+      });
+    })
+  })
+
+  return documents;
+}
+
+function genPaths(ctx: any, file: FileDescriptorProto, service: ServiceDescriptorProto) {
+  return service.method.reduce((paths, method) => {
+    const description = genDescription(ctx, method);
+
+    paths[`/${file.package}.${service.name}/${method.name}`] = {
+      post: {
+        summary: description,
+        operationId: `${service.name}_${method.name}`,
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: {
+                $ref: genRef(ctx, method.inputType!)
+              }
+            }
+          }
+        },
+        responses: {
+          "200": {
+            description: "OK",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: genRef(ctx, method.outputType!),
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    return paths;
+  }, {} as OpenAPIV3.PathsObject)
+}
+
+function genComponents(ctx: any, methods: MethodDescriptorProto[]) {
+  const components: OpenAPIV3.ComponentsObject = {
+    schemas: {}
+  };
+
+  methods.reduce((schemas, method) => {
+    genSchema(ctx, schemas, method.inputType!);
+    genSchema(ctx, schemas, method.outputType!);
+
+    return schemas;
+  }, components.schemas)
+
+  return components;
+}
+
+function genSchema(ctx: any, schemas: OpenAPIV3.ComponentsObject["schemas"], typeName: string)  {
+  const registry = ctx.registry as DescriptorRegistry;
+
+  const localName = localMessageName(ctx, typeName);
+
+  if (!localName) {
+    return;
+  }
+
+  const descriptor = registry.resolveTypeName(typeName) as DescriptorProto;
+
+  if (schemas![localName] || registry.isSyntheticElement(descriptor)) {
+    return;
+  }
+
+  if (descriptor.field.some((field) => registry.isUserDeclaredOneof(field))) {
+    schemas![localName] = genOneOfType(ctx, descriptor);
+    schemas![`${localName}__Kind`] = genOneOfTypeKind(ctx, descriptor);
+  } else {
+    schemas![localName] = genType(ctx, descriptor);
+  }
+
+  descriptor.field.forEach((field) => {
+    if (field.type !== FieldDescriptorProto_Type.MESSAGE) {
+      return;
+    }
+
+    if (registry.isSyntheticElement(descriptor)) {
+      return;
+    }
+
+    genSchema(ctx, schemas, field.typeName!);
+  })
+}
+
+function genType(ctx: any, message: DescriptorProto): OpenAPIV3.SchemaObject {
+  const description = genDescription(ctx, message)
+
+  return {
+    properties: genMessageProperties(ctx, message),
+    description,
+  }
+}
+
+function genOneOfType(ctx: any, message: DescriptorProto): OpenAPIV3.SchemaObject {
+  const description = genDescription(ctx, message)
+
+  return {
+    allOf: [
+      {
+        type: "object",
+        properties: genMessageProperties(ctx, message),
+      },
+      {
+        $ref: `#/components/schemas/${message.name}__Kind`
+      }
+    ],
+    description,
+  }
+}
+
+function genOneOfTypeKind(ctx: any, message: DescriptorProto): OpenAPIV3.SchemaObject {
+  const registry = ctx.registry as DescriptorRegistry;
+
+  return {
+    oneOf: message.field.filter((field) => {
+      return registry.isUserDeclaredOneof(field)
+    }).map((oneOf) => {
+      return {
+        type: "object",
+        properties: {
+          [oneOf.name!]: {
+            $ref: genRef(ctx, oneOf.typeName!)
+          },
+        }
+      }
+    })
+  }
+
+}
+
+function genMessageProperties(ctx: any, message: DescriptorProto): OpenAPIV3.SchemaObject["properties"] {
+  const registry = ctx.registry as DescriptorRegistry;
+
+  return message.field.reduce((fields, field) => {
+
+    if (registry.isUserDeclaredOneof(field)) {
+      return fields
+    }
+
+    fields![field.name!] = genField(ctx, field!)
+
+    return fields
+  }, {} as OpenAPIV3.SchemaObject["properties"]);
+}
+
+
+function genRef(ctx: any, name: string) {
+  const messageType = localMessageName(ctx, name)
+  return `#/components/schemas/${messageType}`
+}
+
+function localMessageName(ctx: any, name: string) {
+  const registry = ctx.registry as DescriptorRegistry;
+  const symbols = ctx.symbols as SymbolTable;
+
+  const entry = symbols.find(registry.resolveTypeName(name!))!;
+
+  if (!entry) {
+    return "";
+  }
+
+  return createLocalTypeName(entry.descriptor, registry);
+}
+
+function genField(ctx: any, field: FieldDescriptorProto): OpenAPIV3.ReferenceObject | OpenAPIV3.SchemaObject {
+  let openApiType: OpenAPIV3.SchemaObject | OpenAPIV3.ReferenceObject
+  const registry = ctx.registry as DescriptorRegistry;
+
+  switch (field.type) {
+    case FieldDescriptorProto_Type.DOUBLE:
+    case FieldDescriptorProto_Type.FLOAT:
+    case FieldDescriptorProto_Type.BOOL:
+    case FieldDescriptorProto_Type.STRING:
+    case FieldDescriptorProto_Type.FIXED32:
+    case FieldDescriptorProto_Type.FIXED64:
+    case FieldDescriptorProto_Type.INT32:
+    case FieldDescriptorProto_Type.INT64:
+    case FieldDescriptorProto_Type.SFIXED32:
+    case FieldDescriptorProto_Type.SFIXED64:
+    case FieldDescriptorProto_Type.SINT32:
+    case FieldDescriptorProto_Type.SINT64:
+    case FieldDescriptorProto_Type.UINT32:
+    case FieldDescriptorProto_Type.UINT64:
+      openApiType = {
+        type: genScalar(field.type),
+      }
+      break;
+    case FieldDescriptorProto_Type.BYTES:
+      openApiType = {
+        type: "array",
+        items: {
+          type: "integer",
+        }
+      }
+      break;
+    case FieldDescriptorProto_Type.ENUM:
+      const enumType = registry.getEnumFieldEnum(field)
+      openApiType = genEnum(enumType);
+      break;
+    case FieldDescriptorProto_Type.MESSAGE:
+
+      // Map type
+      if (registry.isMapField(field)) {
+        const mapTypeValue = registry.getMapValueType(field)
+
+        if (typeof mapTypeValue === "number") {
+          const scalar = mapTypeValue as ScalarValueType;
+          openApiType = {
+            type: "object",
+            additionalProperties: {
+              type: genScalar(scalar)
+            }
+          }
+        } else if (EnumDescriptorProto.is(field)) {
+          openApiType = {
+            type: "object",
+            additionalProperties: {
+              ...genEnum(field)
+            }
+          }
+        } else if (DescriptorProto.is(field)) {
+          openApiType = {
+            type: "object",
+            additionalProperties: {
+              $ref: genRef(ctx, field.name!),
+            }
+          }
+        } else {
+          throw new Error("map value not supported")
+        }
+        break
+      }
+
+      openApiType = {
+        $ref: genRef(ctx, field.typeName!),
+      }
+      break
+    default:
+      throw new Error(`${field.name} of type ${field.type} not supported`)
+  }
+
+  const description = genDescription(ctx, field)
+
+  if (field.label === FieldDescriptorProto_Label.REPEATED && !registry.isMapField(field)) {
+    return {
+      type: "array",
+      items: openApiType,
+      description: description || "",
+    }
+  }
+
+  if (field.type !== FieldDescriptorProto_Type.MESSAGE) {
+    (openApiType as OpenAPIV3.SchemaObject).description = description || "";
+  }
+
+  return openApiType;
+}
+
+function genEnum(enumType: EnumDescriptorProto): OpenAPIV3.SchemaObject {
+  return {
+    type: 'string',
+    enum: enumType.value.map((value) => {
+      return value.name
+    })
+  }
+}
+
+function genScalar(type: FieldDescriptorProto_Type) {
+  switch (type) {
+    case FieldDescriptorProto_Type.BOOL:
+      return "boolean"
+    case FieldDescriptorProto_Type.DOUBLE:
+    case FieldDescriptorProto_Type.FLOAT:
+      return "number"
+    case FieldDescriptorProto_Type.STRING:
+      return "string"
+    case FieldDescriptorProto_Type.FIXED32:
+    case FieldDescriptorProto_Type.FIXED64:
+    case FieldDescriptorProto_Type.INT32:
+    case FieldDescriptorProto_Type.INT64:
+    case FieldDescriptorProto_Type.SFIXED32:
+    case FieldDescriptorProto_Type.SFIXED64:
+    case FieldDescriptorProto_Type.SINT32:
+    case FieldDescriptorProto_Type.SINT64:
+    case FieldDescriptorProto_Type.UINT32:
+    case FieldDescriptorProto_Type.UINT64:
+      return "integer"
+    default:
+      throw new Error(`${type} is not a scalar value`)
+  }
+}
+
+function genDescription(ctx: any, descriptor: AnyDescriptorProto) {
+  const registry = ctx.registry as DescriptorRegistry;
+
+  const source = registry.sourceCodeComments(descriptor);
+  const description = source.leading || source.trailing || "";
+
+  return description.trim();
+}

--- a/src/protoc-gen-twirp-ts/gen/open-api.ts
+++ b/src/protoc-gen-twirp-ts/gen/open-api.ts
@@ -1,7 +1,8 @@
 import {
   AnyDescriptorProto,
   DescriptorProto,
-  DescriptorRegistry, EnumDescriptorProto,
+  DescriptorRegistry,
+  EnumDescriptorProto,
   FieldDescriptorProto,
   FieldDescriptorProto_Label,
   FieldDescriptorProto_Type,
@@ -14,14 +15,25 @@ import {
 import * as yaml from 'yaml';
 import { OpenAPIV3 } from "openapi-types";
 import { createLocalTypeName } from "../local-type-name";
-import * as fs from "fs";
+import { getMethod, HttpOption, Pattern } from "./gateway";
 
 interface OpenAPIDoc {
   fileName: string,
   content: string,
 }
 
-export async function genOpenAPI(ctx: any, files: readonly FileDescriptorProto[]) {
+export enum OpenAPIType {
+  GATEWAY,
+  TWIRP
+}
+
+/**
+ * Generate twirp compliant OpenAPI doc
+ * @param ctx
+ * @param files
+ * @param type
+ */
+export async function genOpenAPI(ctx: any, files: readonly FileDescriptorProto[], type: OpenAPIType) {
   const documents: OpenAPIDoc[] = [];
 
   files.forEach(file => {
@@ -30,14 +42,20 @@ export async function genOpenAPI(ctx: any, files: readonly FileDescriptorProto[]
         openapi: "3.0.3",
         info: {
           title: `${service.name}`,
-          version: "" // TODO
+          version: "1.0.0"
         },
-        paths: genPaths(ctx, file, service),
+        paths: type === OpenAPIType.TWIRP ?
+          genTwirpPaths(ctx, file, service) :
+          genGatewayPaths(ctx, file, service),
         components: genComponents(ctx, service.method),
       }
 
+      const fileName = type === OpenAPIType.TWIRP ?
+        `${service.name?.toLowerCase()}.twirp.yaml` :
+        `${service.name?.toLowerCase()}.yaml`
+
       documents.push({
-        fileName: `${service.name?.toLowerCase()}.twirp.yaml`,
+        fileName,
         content: yaml.stringify(document),
       });
     })
@@ -46,7 +64,13 @@ export async function genOpenAPI(ctx: any, files: readonly FileDescriptorProto[]
   return documents;
 }
 
-function genPaths(ctx: any, file: FileDescriptorProto, service: ServiceDescriptorProto) {
+/**
+ * Generates OpenAPI Twirp URI paths
+ * @param ctx
+ * @param file
+ * @param service
+ */
+function genTwirpPaths(ctx: any, file: FileDescriptorProto, service: ServiceDescriptorProto) {
   return service.method.reduce((paths, method) => {
     const description = genDescription(ctx, method);
 
@@ -82,6 +106,190 @@ function genPaths(ctx: any, file: FileDescriptorProto, service: ServiceDescripto
   }, {} as OpenAPIV3.PathsObject)
 }
 
+/**
+ * Generates OpenAPI Twrip Gateway URI paths
+ * @param ctx
+ * @param file
+ * @param service
+ */
+function genGatewayPaths(ctx: any, file: FileDescriptorProto, service: ServiceDescriptorProto) {
+  const registry = ctx.registry as DescriptorRegistry;
+
+  /**
+   * Build paths recursively
+   * @param method
+   * @param httpSpec
+   * @param paths
+   */
+  function buildPath(method: MethodDescriptorProto, httpSpec: HttpOption, paths: OpenAPIV3.PathsObject) {
+    const httpMethod = getMethod(httpSpec)
+    const description = genDescription(ctx, method);
+
+    const pathItem = {
+      [httpMethod]: {
+        summary: description,
+        operationId: `${service.name}_${method.name}`,
+      }
+    } as OpenAPIV3.PathItemObject
+
+    const inputMessage = registry.resolveTypeName(method.inputType!) as DescriptorProto;
+    const outPutMessage = registry.resolveTypeName(method.outputType!) as DescriptorProto;
+
+    // All methods except GET have body
+    if (httpMethod !== Pattern.GET) {
+      pathItem[httpMethod]!.requestBody = genGatewayBody(ctx, httpSpec, inputMessage)
+    }
+
+    // All methods might have params
+    pathItem[httpMethod]!.parameters = genGatewayParams(ctx, httpSpec, inputMessage)
+    pathItem[httpMethod]!.responses = genGatewayResponse(ctx, httpSpec, outPutMessage)
+
+    paths[`${httpSpec[httpMethod]}`] = pathItem;
+
+    if (httpSpec.additional_bindings) {
+      buildPath(method, httpSpec.additional_bindings, paths)
+    }
+  }
+
+  return service.method.reduce((paths, method) => {
+    const options = ctx.interpreter.readOptions(method);
+
+    if (!options && options["google.api.http"]) {
+      return paths;
+    }
+
+    const httpSpec = options["google.api.http"] as HttpOption
+
+    buildPath(method, httpSpec, paths);
+
+    return paths;
+  }, {} as OpenAPIV3.PathsObject)
+}
+
+/**
+ * Generate OpenAPI Gateway Response
+ * @param ctx
+ * @param httpOptions
+ * @param message
+ */
+function genGatewayResponse(ctx: any, httpOptions: HttpOption, message: DescriptorProto): OpenAPIV3.ResponsesObject {
+  let schema: OpenAPIV3.ReferenceObject | OpenAPIV3.SchemaObject = {};
+
+  if (httpOptions.responseBody !== "") {
+    schema = {
+      type: "object",
+      properties: {
+        [httpOptions.responseBody]: {
+          $ref: `#/components/schemas/${message.name}`
+        }
+      }
+    }
+  } else {
+    schema = {
+      $ref: `#/components/schemas/${message.name}`
+    }
+  }
+
+  return {
+    "200": {
+      description: "OK",
+      content: {
+        "application/json": {
+          schema,
+        }
+      }
+    }
+  }
+}
+
+/**
+ * Generate OpenAPI Gateway Response
+ * @param ctx
+ * @param httpOptions
+ * @param message
+ */
+function genGatewayBody(ctx: any, httpOptions: HttpOption, message: DescriptorProto): OpenAPIV3.RequestBodyObject {
+  const schema: OpenAPIV3.ReferenceObject | OpenAPIV3.SchemaObject = {}
+
+  if (httpOptions.body === "*") {
+    (schema as OpenAPIV3.ReferenceObject).$ref = `#/components/schemas/${message.name}`
+  } else {
+    const subField = message.field.find(field => field.name === httpOptions.body);
+
+    if (!subField) {
+      throw new Error(`the body field ${httpOptions.body} cannot be mapped to message ${message.name}`)
+    }
+
+    schema.properties = {
+      [httpOptions.body]: genField(ctx, subField),
+    }
+  }
+
+  return {
+    required: true,
+    content: {
+      "application/json": {
+        schema,
+      }
+    }
+  }
+}
+
+/**
+ * Generates OpenAPI Gateway Parameters
+ * @param ctx
+ * @param httpOptions
+ * @param message
+ */
+function genGatewayParams(ctx: any, httpOptions: HttpOption, message: DescriptorProto): (OpenAPIV3.ReferenceObject | OpenAPIV3.ParameterObject)[] {
+  const httpMethod = getMethod(httpOptions)
+  const params = parseUriParams(httpOptions[httpMethod])
+
+  const urlParams = message.field
+    .filter((field) =>
+      params.find((param) => param === field.name)
+    )
+    .map((field) => {
+      return {
+        name: field.name,
+        in: "path",
+        required: true,
+        schema: {
+          ...genField(ctx, field)
+        }
+      } as OpenAPIV3.ParameterObject
+    })
+
+  if (httpOptions.body === "*") {
+    return urlParams
+  }
+
+  const queryString = message.field
+    .filter((field) =>
+      field.name !== httpOptions.body &&
+      !params.find(param => param === field.name!)
+    )
+    .map((field) => {
+      return {
+        name: field.name,
+        in: "query",
+        schema: {
+          ...genField(ctx, field)
+        }
+      } as OpenAPIV3.ParameterObject
+    })
+
+  return [
+    ...queryString,
+    ...urlParams,
+  ]
+}
+
+/**
+ * Generates OpenAPI Components
+ * @param ctx
+ * @param methods
+ */
 function genComponents(ctx: any, methods: MethodDescriptorProto[]) {
   const components: OpenAPIV3.ComponentsObject = {
     schemas: {}
@@ -97,7 +305,13 @@ function genComponents(ctx: any, methods: MethodDescriptorProto[]) {
   return components;
 }
 
-function genSchema(ctx: any, schemas: OpenAPIV3.ComponentsObject["schemas"], typeName: string)  {
+/**
+ * Generate OpenAPI Schemas
+ * @param ctx
+ * @param schemas
+ * @param typeName
+ */
+function genSchema(ctx: any, schemas: OpenAPIV3.ComponentsObject["schemas"], typeName: string) {
   const registry = ctx.registry as DescriptorRegistry;
 
   const localName = localMessageName(ctx, typeName);
@@ -112,9 +326,18 @@ function genSchema(ctx: any, schemas: OpenAPIV3.ComponentsObject["schemas"], typ
     return;
   }
 
+  // Handle OneOf
   if (descriptor.field.some((field) => registry.isUserDeclaredOneof(field))) {
     schemas![localName] = genOneOfType(ctx, descriptor);
-    schemas![`${localName}__Kind`] = genOneOfTypeKind(ctx, descriptor);
+
+    descriptor.oneofDecl.forEach((oneOfField, index) => {
+      const oneOfTyName = `${localName}_${capitalizeFirstLetter(oneOfField.name!)}`;
+
+      const oneOfFields = descriptor.field.filter(field => {
+        return field.oneofIndex === index;
+      })
+      schemas![oneOfTyName] = genOneOfTypeKind(ctx, descriptor, oneOfFields);
+    })
   } else {
     schemas![localName] = genType(ctx, descriptor);
   }
@@ -132,6 +355,11 @@ function genSchema(ctx: any, schemas: OpenAPIV3.ComponentsObject["schemas"], typ
   })
 }
 
+/**
+ * Generate an OpenAPI type
+ * @param ctx
+ * @param message
+ */
 function genType(ctx: any, message: DescriptorProto): OpenAPIV3.SchemaObject {
   const description = genDescription(ctx, message)
 
@@ -141,36 +369,46 @@ function genType(ctx: any, message: DescriptorProto): OpenAPIV3.SchemaObject {
   }
 }
 
+/**
+ * Generate a Protobuf to OpenAPI oneof type
+ * @param ctx
+ * @param message
+ */
 function genOneOfType(ctx: any, message: DescriptorProto): OpenAPIV3.SchemaObject {
   const description = genDescription(ctx, message)
 
-  return {
+  const oneOf = {
     allOf: [
       {
         type: "object",
         properties: genMessageProperties(ctx, message),
       },
-      {
-        $ref: `#/components/schemas/${message.name}__Kind`
-      }
-    ],
+    ] as (OpenAPIV3.ReferenceObject | OpenAPIV3.SchemaObject)[],
     description,
   }
+
+  message.oneofDecl.forEach((field) => {
+    oneOf.allOf.push({
+      $ref: `#/components/schemas/${message.name}_${capitalizeFirstLetter(field.name!)}`
+    })
+  })
+
+  return oneOf;
 }
 
-function genOneOfTypeKind(ctx: any, message: DescriptorProto): OpenAPIV3.SchemaObject {
-  const registry = ctx.registry as DescriptorRegistry;
-
+/**
+ * Generate one of type
+ * @param ctx
+ * @param message
+ * @param oneOfFields
+ */
+function genOneOfTypeKind(ctx: any, message: DescriptorProto, oneOfFields: FieldDescriptorProto[]): OpenAPIV3.SchemaObject {
   return {
-    oneOf: message.field.filter((field) => {
-      return registry.isUserDeclaredOneof(field)
-    }).map((oneOf) => {
+    oneOf: oneOfFields.map((oneOf) => {
       return {
         type: "object",
         properties: {
-          [oneOf.name!]: {
-            $ref: genRef(ctx, oneOf.typeName!)
-          },
+          [oneOf.name!]: genField(ctx, oneOf),
         }
       }
     })
@@ -178,6 +416,11 @@ function genOneOfTypeKind(ctx: any, message: DescriptorProto): OpenAPIV3.SchemaO
 
 }
 
+/**
+ * Generate message properties
+ * @param ctx
+ * @param message
+ */
 function genMessageProperties(ctx: any, message: DescriptorProto): OpenAPIV3.SchemaObject["properties"] {
   const registry = ctx.registry as DescriptorRegistry;
 
@@ -193,25 +436,21 @@ function genMessageProperties(ctx: any, message: DescriptorProto): OpenAPIV3.Sch
   }, {} as OpenAPIV3.SchemaObject["properties"]);
 }
 
-
+/**
+ * Generates OpenAPI $ref
+ * @param ctx
+ * @param name
+ */
 function genRef(ctx: any, name: string) {
   const messageType = localMessageName(ctx, name)
   return `#/components/schemas/${messageType}`
 }
 
-function localMessageName(ctx: any, name: string) {
-  const registry = ctx.registry as DescriptorRegistry;
-  const symbols = ctx.symbols as SymbolTable;
-
-  const entry = symbols.find(registry.resolveTypeName(name!))!;
-
-  if (!entry) {
-    return "";
-  }
-
-  return createLocalTypeName(entry.descriptor, registry);
-}
-
+/**
+ * Generate field definition
+ * @param ctx
+ * @param field
+ */
 function genField(ctx: any, field: FieldDescriptorProto): OpenAPIV3.ReferenceObject | OpenAPIV3.SchemaObject {
   let openApiType: OpenAPIV3.SchemaObject | OpenAPIV3.ReferenceObject
   const registry = ctx.registry as DescriptorRegistry;
@@ -306,6 +545,10 @@ function genField(ctx: any, field: FieldDescriptorProto): OpenAPIV3.ReferenceObj
   return openApiType;
 }
 
+/**
+ * Generates enum definition
+ * @param enumType
+ */
 function genEnum(enumType: EnumDescriptorProto): OpenAPIV3.SchemaObject {
   return {
     type: 'string',
@@ -315,6 +558,10 @@ function genEnum(enumType: EnumDescriptorProto): OpenAPIV3.SchemaObject {
   }
 }
 
+/**
+ * Generate scalar
+ * @param type
+ */
 function genScalar(type: FieldDescriptorProto_Type) {
   switch (type) {
     case FieldDescriptorProto_Type.BOOL:
@@ -340,6 +587,11 @@ function genScalar(type: FieldDescriptorProto_Type) {
   }
 }
 
+/**
+ * Generates the description
+ * @param ctx
+ * @param descriptor
+ */
 function genDescription(ctx: any, descriptor: AnyDescriptorProto) {
   const registry = ctx.registry as DescriptorRegistry;
 
@@ -347,4 +599,40 @@ function genDescription(ctx: any, descriptor: AnyDescriptorProto) {
   const description = source.leading || source.trailing || "";
 
   return description.trim();
+}
+
+/**
+ * Format protobuf name
+ * @param ctx
+ * @param name
+ */
+function localMessageName(ctx: any, name: string) {
+  const registry = ctx.registry as DescriptorRegistry;
+  const symbols = ctx.symbols as SymbolTable;
+
+  const entry = symbols.find(registry.resolveTypeName(name!))!;
+
+  if (!entry) {
+    return "";
+  }
+
+  return createLocalTypeName(entry.descriptor, registry);
+}
+
+function parseUriParams(uri: string) {
+  return getMatches(uri, /{([a-zA-Z_0-9]+)}/g, 1)
+}
+
+function getMatches(str: string, regex: RegExp, index: number = 1) {
+  const matches = [];
+  let match;
+  while (match = regex.exec(str)) {
+    matches.push(match[index]);
+  }
+  return matches;
+}
+
+
+function capitalizeFirstLetter(str: string) {
+  return str.charAt(0).toUpperCase() + str.slice(1);
 }

--- a/src/protoc-gen-twirp-ts/plugin.ts
+++ b/src/protoc-gen-twirp-ts/plugin.ts
@@ -10,7 +10,7 @@ import { generate } from "./gen/twirp";
 import { genGateway } from "./gen/gateway";
 import { createLocalTypeName } from "./local-type-name";
 import { Interpreter } from "./interpreter";
-import { genOpenAPI } from "./gen/open-api";
+import { genOpenAPI, OpenAPIType } from "./gen/open-api";
 
 export class ProtobuftsPlugin extends PluginBase<File> {
 
@@ -26,6 +26,12 @@ export class ProtobuftsPlugin extends PluginBase<File> {
     },
     emit_default_values: {
       description: "Json encode and decode will emit default values"
+    },
+    openapi_twirp: {
+      description: "Generates an OpenAPI spec for twirp handlers"
+    },
+    openapi_gateway: {
+      description: "Generates an OpenAPI spec for gateway handlers"
     }
   }
 
@@ -75,7 +81,18 @@ export class ProtobuftsPlugin extends PluginBase<File> {
     }
 
     // Open API
-    const docs = await genOpenAPI(ctx, registry.allFiles())
+    const docs = [];
+    if (params.openapi_twirp) {
+      docs.push(
+        ...(await genOpenAPI(ctx, registry.allFiles(), OpenAPIType.TWIRP)),
+      )
+    }
+
+    if (params.openapi_gateway) {
+      docs.push(
+        ...(await genOpenAPI(ctx, registry.allFiles(), OpenAPIType.GATEWAY)),
+      )
+    }
 
     docs.forEach((doc) => {
       const file = new File(`${doc.fileName}`)

--- a/src/protoc-gen-twirp-ts/plugin.ts
+++ b/src/protoc-gen-twirp-ts/plugin.ts
@@ -10,7 +10,7 @@ import { generate } from "./gen/twirp";
 import { genGateway } from "./gen/gateway";
 import { createLocalTypeName } from "./local-type-name";
 import { Interpreter } from "./interpreter";
-import * as fs from "fs";
+import { genOpenAPI } from "./gen/open-api";
 
 export class ProtobuftsPlugin extends PluginBase<File> {
 
@@ -73,6 +73,15 @@ export class ProtobuftsPlugin extends PluginBase<File> {
     if (params.index_file) {
       files.push(genIndexFile(registry, [...files]));
     }
+
+    // Open API
+    const docs = await genOpenAPI(ctx, registry.allFiles())
+
+    docs.forEach((doc) => {
+      const file = new File(`${doc.fileName}`)
+      file.setContent(doc.content)
+      files.push(file)
+    })
 
     return files;
   }


### PR DESCRIPTION
## Open API V3

You can now generate automatically an **OpenAPI V3** compliant spec out of your twirp protobuf definitions!

We support the **Gateway** too!

Add the following options to your `protoc` command:

```
--twirp_ts_opt="openapi_twirp" 
--twirp_ts_opt="openapi_gateway"
```

Enjoy!

Closes #8 