### PR TITLE
Add client/server generation options

### DIFF
--- a/src/protoc-gen-twirp-ts/gen/twirp.ts
+++ b/src/protoc-gen-twirp-ts/gen/twirp.ts
@@ -18,12 +18,16 @@ const TwirpErrorCode = imp("TwirpErrorCode@twirp-ts");
  * @param ctx
  * @param file
  */
-export async function generate(ctx: any, file: FileDescriptorProto) {
+export async function generate(ctx: any, file: FileDescriptorProto, disableClient: boolean, disableServer: boolean) {
     const contents = file.service.map((service) => {
-        return joinCode([
-            genClient(ctx, file, service),
-            genServer(ctx, file, service)
-        ], { on: "\n\n" })
+        let genCode = [];
+        if (!disableClient) {
+          genCode.push(genClient(ctx, file, service))
+        }
+        if (!disableServer) {
+          genCode.push(genServer(ctx, file, service))
+        }
+        return joinCode(genCode, { on: "\n\n" })
     });
 
     return joinCode(contents, { on: "\n\n"}).toStringWithImports();

--- a/src/protoc-gen-twirp-ts/plugin.ts
+++ b/src/protoc-gen-twirp-ts/plugin.ts
@@ -32,7 +32,13 @@ export class ProtobuftsPlugin extends PluginBase<File> {
     },
     openapi_gateway: {
       description: "Generates an OpenAPI spec for gateway handlers"
-    }
+    },
+    disable_client_generation: {
+      description: "Disable client code generation"
+    },
+    disable_server_generation: {
+      description: "Disable server code generation"
+    },
   }
 
   async generate(request: CodeGeneratorRequest): Promise<File[]> {
@@ -62,7 +68,7 @@ export class ProtobuftsPlugin extends PluginBase<File> {
 
       // Twirp generation
       const twirpFileOut = new File(`${fileDescriptor.name?.replace(".proto", "").toLowerCase()}.twirp.ts`);
-      const twirpContent = await generate(ctx, fileDescriptor);
+      const twirpContent = await generate(ctx, fileDescriptor, params.disable_client_generation, params.disable_server_generation);
       twirpFileOut.setContent(twirpContent);
       files.push(twirpFileOut);
     }


### PR DESCRIPTION
This patch adds two options to modify the code generation behaviour.

```
--twirp_ts_opt=disable_client_generation # disables Twirp client code generation
--twirp_ts_opt=disable_server_generation # disables Twirp server code generation
```