### PR TITLE
Fix for empty body

### DIFF
--- a/src/protoc-gen-twirp-ts/gen/open-api.ts
+++ b/src/protoc-gen-twirp-ts/gen/open-api.ts
@@ -214,7 +214,7 @@ function genGatewayBody(ctx: any, httpOptions: HttpOption, message: DescriptorPr
 
   if (httpOptions.body === "*") {
     (schema as OpenAPIV3.ReferenceObject).$ref = `#/components/schemas/${message.name}`
-  } else {
+  } else if (httpOptions.body) {
     const subField = message.field.find(field => field.name === httpOptions.body);
 
     if (!subField) {


### PR DESCRIPTION
The swagger generatator for an empty body fails for a rpc such as 

```protobuf
rpc DeleteObject(DeleteObjectRequest) returns (Empty) {
    option (google.api.http) = {
      delete: "/v1/objects/{object_id}"
    };
  };
```