### PR TITLE
Add peer meta to prevent warning of missing peer dependancies

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,5 +47,13 @@
   "peerDependencies": {
     "@protobuf-ts/plugin": "^2.0.0-alpha.27",
     "ts-proto": "^1.81.3"
+  },
+  "peerDependenciesMeta": {
+    "@protobuf-ts/plugin": {
+      "optional": true
+    },
+    "ts-proto": {
+      "optional": true
+    }
   }
 }


### PR DESCRIPTION
See https://docs.npmjs.com/cli/v7/configuring-npm/package-json#peerdependenciesmeta

right now when installing twirp-ts you will always get one of two warnings

```
npm WARN twirp-ts@2.4.1 requires a peer of @protobuf-ts/plugin@^2.0.0-alpha.27 but none is installed. You must install peer dependencies yourself.

npm WARN twirp-ts@2.4.1 requires a peer of ts-proto@^1.81.3 but none is installed. You must install peer dependencies yourself.
```

depending on which implementation you use, this prevents these warnings.