### PR TITLE
Add name property to TwirpError

### DIFF
--- a/src/twirp/errors.ts
+++ b/src/twirp/errors.ts
@@ -5,6 +5,7 @@ export class TwirpError extends Error {
   public readonly msg: string;
   public readonly code: TwirpErrorCode = TwirpErrorCode.Internal;
   public readonly meta: Record<string, string> = {};
+  public readonly name = "TwirpError";
 
   private _originalCause?: Error;
 

--- a/src/twirp/errors.ts
+++ b/src/twirp/errors.ts
@@ -5,12 +5,12 @@ export class TwirpError extends Error {
   public readonly msg: string;
   public readonly code: TwirpErrorCode = TwirpErrorCode.Internal;
   public readonly meta: Record<string, string> = {};
-  public readonly name = "TwirpError";
 
   private _originalCause?: Error;
 
   constructor(code: TwirpErrorCode, msg: string) {
     super(msg);
+    this.name = "TwirpError";
     this.code = code;
     this.msg = msg;
     Object.setPrototypeOf(this, TwirpError.prototype);


### PR DESCRIPTION
We are using TwirpError together with [VError](https://github.com/TritonDataCenter/node-verror), more specifically the [findCauseByName](https://github.com/TritonDataCenter/node-verror/blob/master/lib/verror.js#L273-L289) utility to find errors of specific kinds based on the `.name` property.

As `twirp-ts` does not set a custom `name` property on `TwirpError`, we have to rely on using `instanceof TwirpError`, which works but is a bit unexpected.

Wanted to open an issue, but figured I'd open this PR to propose + discuss. Feel free to close if this isn't something you want to add 👍 