### PR TITLE
Update context after route has been matched

### DIFF
--- a/src/twirp/server.ts
+++ b/src/twirp/server.ts
@@ -178,7 +178,7 @@ export class TwirpServer<
     req: http.IncomingMessage,
     resp: http.ServerResponse
   ) {
-    const ctx = this.createContext(req, resp);
+    let ctx = this.createContext(req, resp);
 
     try {
       await this.invokeHook("requestReceived", ctx);
@@ -190,7 +190,11 @@ export class TwirpServer<
       );
 
       const handler = this.matchRoute(method, {
-        onMatch: (ctx) => {
+        onMatch: (_ctx) => {
+          // Update parent context with the matched context so that the
+          // matched handler details are included
+          ctx = _ctx
+
           return this.invokeHook("requestRouted", ctx);
         },
         onNotFound: () => {


### PR DESCRIPTION
By updating the context to include the method name it ensures this is available in future hooks

My use case for this change is that we use a hooks to instrument our RPC handlers. We would like the method name available in the error hook so that we can observe what handlers are erroring.